### PR TITLE
Add support for azurerm 2.x and azurecaf providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0 (March 2020)
+
+FEATURES: 
+* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#9](https://github.com/aztfmod/terraform-azurerm-caf-public-ip/issues/9))
+* **improvement:** Replace input parameter ```rg``` as ```resource_group_name```
+
 ## v1.0 (January 2020)
 
 FEATURES: 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build status](https://dev.azure.com/azure-terraform/Blueprints/_apis/build/status/modules/public_ip_address)](https://dev.azure.com/azure-terraform/Blueprints/_build/latest?definitionId=0)
+[![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 # Deploys a public IP address
 Creates an Azure public IP address (IPv4 or IPv6)
 
@@ -10,7 +11,7 @@ module "public_ip_address" {
 
     name                              = var.name
     location                          = var.location
-    rg                                = var.rg
+    resource_group_name               = var.rg
     ip_addr                           = var.ipconfig
     diagnostics_settings              = var.ipdiags
     diagnostics_map                   = var.diagsmap
@@ -23,19 +24,21 @@ module "public_ip_address" {
 | Name | Type | Default | Description | 
 | -- | -- | -- | -- | 
 | name | string | None | Name of the public IP to be created |
-| rg | string | None | Name of the resource group where to create the resource. Changing this forces a new resource to be created. |
+| resource_group_name | string | None | Name of the resource group where to create the resource. Changing this forces a new resource to be created. |
 | location | string | None | Specifies the Azure location to deploy the resource. Changing this forces a new resource to be created.  | 
 | tags | map | None | Map of tags for the deployment.  | 
 | log_analytics_workspace_id | string | None | Log Analytics Workspace ID. | 
 | diagnostics_map | map | None | Map with the diagnostics repository information.  | 
 | diagnostics_settings | object | None | Map with the diagnostics settings. See the required structure in the following example or in the diagnostics module documentation. | 
 | convention | string | None | Naming convention to be used (check at the naming convention module for possible values).  | 
-| prefix | string | None | Prefix to be used (to be deprecated). | 
+| prefix | string | None | (Optional) Prefix to be used. |
+| postfix | string | None | (Optional) Postfix to be used. |
+| max_length | string | None | (Optional) maximum length to the name of the resource. |
 | ip_addr | object | None | Object with the settings for public IP deployment.  | 
 
 ## Parameters
 
-## ip_addr
+### ip_addr
 (Required) The configuration object describing the public IP configuration
 Mandatory properties are:
 - allocation_method

--- a/examples/pip_single/locals.tf
+++ b/examples/pip_single/locals.tf
@@ -1,5 +1,5 @@
 locals {
-    convention = "cafrandom"
+    convention = "cafclassic"
     name = "caftest"
     location = "southeastasia"
     prefix = ""
@@ -22,7 +22,7 @@ locals {
     enable_event_hub = false
     
     ip_addr_config = {
-        ip_name = "arnaud-pip-egress"    
+        ip_name = "arnaud-egress"    
         allocation_method   = "Static"
         #Dynamic Public IP Addresses aren't allocated until they're assigned to a resource (such as a Virtual Machine or a Load Balancer) by design within Azure 
         

--- a/examples/pip_single/pip_single.tf
+++ b/examples/pip_single/pip_single.tf
@@ -15,9 +15,10 @@ resource "azurerm_resource_group" "rg_test" {
 }
 
 module "la_test" {
-  source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "1.0.0"
-  
+  # source  = "aztfmod/caf-log-analytics/azurerm"
+  # version = "1.0.0"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-log-analytics?ref=2003-refresh" 
+
     convention          = local.convention
     location            = local.location
     name                = local.name
@@ -28,8 +29,9 @@ module "la_test" {
 }
 
 module "diags_test" {
-  source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "1.0.0"
+  # source  = "aztfmod/caf-diagnostics-logging/azurerm"
+  # version = "1.0.0"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-diagnostics-logging?ref=2003-refresh"
 
   convention            = local.convention
   name                  = local.name

--- a/examples/pip_single/pip_single.tf
+++ b/examples/pip_single/pip_single.tf
@@ -46,7 +46,7 @@ module "public_ip_test" {
   convention                       = local.convention
   name                             = local.ip_addr_config.ip_name
   location                         = local.location
-  rg                               = azurerm_resource_group.rg_test.name
+  resource_group_name              = azurerm_resource_group.rg_test.name
   ip_addr                          = local.ip_addr_config
   tags                             = local.tags
   diagnostics_map                  = module.diags_test.diagnostics_map

--- a/examples/pip_single/pip_single.tf
+++ b/examples/pip_single/pip_single.tf
@@ -15,9 +15,8 @@ resource "azurerm_resource_group" "rg_test" {
 }
 
 module "la_test" {
-  # source  = "aztfmod/caf-log-analytics/azurerm"
-  # version = "1.0.0"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-log-analytics?ref=2003-refresh" 
+  source  = "aztfmod/caf-log-analytics/azurerm"
+  version = "2.0.0"
 
     convention          = local.convention
     location            = local.location
@@ -29,9 +28,8 @@ module "la_test" {
 }
 
 module "diags_test" {
-  # source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  # version = "1.0.0"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-diagnostics-logging?ref=2003-refresh"
+  source  = "aztfmod/caf-diagnostics-logging/azurerm"
+  version = "2.0.0"
 
   convention            = local.convention
   name                  = local.name

--- a/examples/pip_single/pip_single.tf
+++ b/examples/pip_single/pip_single.tf
@@ -1,13 +1,17 @@
+provider azurecaf {}
+
+provider azurerm {
+  features {}
+}
+
+
 data "azurerm_client_config" "current" {
 }
 
-module "rg_test" {
-  source  = "aztfmod/caf-resource-group/azurerm"
-  version = "0.1.1"
-  
-    prefix          = local.prefix
-    resource_groups = local.resource_groups
-    tags            = local.tags
+resource "azurerm_resource_group" "rg_test" {
+  name     = local.resource_groups.test.name
+  location = local.resource_groups.test.location
+  tags     = local.tags
 }
 
 module "la_test" {
@@ -19,7 +23,7 @@ module "la_test" {
     name                = local.name
     solution_plan_map   = local.solution_plan_map 
     prefix              = local.prefix
-    resource_group_name = module.rg_test.names.test
+    resource_group_name = azurerm_resource_group.rg_test.name
     tags                = local.tags
 }
 
@@ -29,7 +33,7 @@ module "diags_test" {
 
   convention            = local.convention
   name                  = local.name
-  resource_group_name   = module.rg_test.names.test
+  resource_group_name   = azurerm_resource_group.rg_test.name
   prefix                = local.prefix
   location              = local.location
   tags                  = local.tags
@@ -42,7 +46,7 @@ module "public_ip_test" {
   convention                       = local.convention
   name                             = local.ip_addr_config.ip_name
   location                         = local.location
-  rg                               = module.rg_test.names.test
+  rg                               = azurerm_resource_group.rg_test.name
   ip_addr                          = local.ip_addr_config
   tags                             = local.tags
   diagnostics_map                  = module.diags_test.diagnostics_map

--- a/module.tf
+++ b/module.tf
@@ -1,14 +1,14 @@
-module "caf_name_pip" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-  
-  name    = var.name
-  type    = "pip"
-  convention  = var.convention
+resource "azurecaf_naming_convention" "caf_name_pip" {  
+  name          = var.name
+  prefix        = var.prefix != "" ? var.prefix : null
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
+  resource_type = "azurerm_public_ip"
+  convention    = var.convention
 }
 
 resource "azurerm_public_ip" "public_ip" {
-  name                      = module.caf_name_pip.pip
+  name                      = azurecaf_naming_convention.caf_name_pip.result
   location                  = var.location
   resource_group_name       = var.rg
   allocation_method         = var.ip_addr.allocation_method

--- a/module.tf
+++ b/module.tf
@@ -10,7 +10,7 @@ resource "azurecaf_naming_convention" "caf_name_pip" {
 resource "azurerm_public_ip" "public_ip" {
   name                      = azurecaf_naming_convention.caf_name_pip.result
   location                  = var.location
-  resource_group_name       = var.rg
+  resource_group_name       = var.resource_group_name
   allocation_method         = var.ip_addr.allocation_method
   tags                      = local.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,22 @@ variable "ip_addr" {
 variable "convention" {
   description = "(Required) Naming convention method to use"  
 }
+
+variable "prefix" {
+  description = "(Optional) You can use a prefix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "postfix" {
+  description = "(Optional) You can use a postfix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "max_length" {
+  description = "(Optional) You can speficy a maximum length to the name of the resource"
+  type        = string
+  default = ""
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "location" {
   description = "(Required) Location of the public IP to be created"   
 }
 
-variable "rg" {
+variable "resource_group_name" {
   description = "(Required) Resource group of the public IP to be created"    
 }
 


### PR DESCRIPTION
## v2.0 (March 2020)

FEATURES: 
* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#9](https://github.com/aztfmod/terraform-azurerm-caf-public-ip/issues/9))
